### PR TITLE
Split interface and implementation for Client

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,11 @@
 {
 	"root": true,
 	"parser": "@typescript-eslint/parser",
-	"plugins": ["@typescript-eslint", "jest", "tsdoc"],
+	"plugins": ["tsdoc"],
 	"extends": [
 		"eslint:recommended",
 		"plugin:@typescript-eslint/recommended",
+		"plugin:promise/recommended",
 		"plugin:jest/recommended",
 		"plugin:jest/style",
 		"prettier",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^7.2.0",
         "eslint-plugin-jest": "^24.1.3",
+        "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-tsdoc": "^0.2.11",
         "jest": "^26.6.3",
         "prettier": "^2.2.1",
@@ -2591,6 +2592,15 @@
       },
       "peerDependencies": {
         "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eslint-plugin-tsdoc": {
@@ -10246,6 +10256,12 @@
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       }
+    },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
     },
     "eslint-plugin-tsdoc": {
       "version": "0.2.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "prettier": "^2.2.1",
         "ts-jest": "^26.4.4",
         "ts-node-dev": "^1.1.1",
+        "typed-emitter": "^1.3.1",
         "typedoc": "^0.20.18",
         "typescript": "^4.1.3"
       }
@@ -7694,6 +7695,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.3.1.tgz",
+      "integrity": "sha512-2h7utWyXgd2R2u2IuL8B4yu1gqMxbgUj2VS/MGVbFhEVQNJKXoQQoS5CBMh+eW31zFeSmDfEQ3qQf4xy5SlPVQ==",
+      "dev": true
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -14183,6 +14190,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typed-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.3.1.tgz",
+      "integrity": "sha512-2h7utWyXgd2R2u2IuL8B4yu1gqMxbgUj2VS/MGVbFhEVQNJKXoQQoS5CBMh+eW31zFeSmDfEQ3qQf4xy5SlPVQ==",
       "dev": true
     },
     "typedarray-to-buffer": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.4.4",
     "ts-node-dev": "^1.1.1",
+    "typed-emitter": "^1.3.1",
     "typedoc": "^0.20.18",
     "typescript": "^4.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^7.18.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-jest": "^24.1.3",
+    "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-tsdoc": "^0.2.11",
     "jest": "^26.6.3",
     "prettier": "^2.2.1",

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,21 +1,4 @@
-import { ClientHttp2Session, connect } from 'http2'
-import { EventEmitter } from 'events'
 import TypedEmitter from 'typed-emitter'
-
-/**
- * String representation of the host and port together.
- *
- * @remarks
- * Needed because IPv6 addresses must be bracketed to disambiguate colons.
- *
- * @param host - hostname or IP address
- * @param port - port number
- * @returns connection string suitable for a URL
- */
-function hostAndPort(host: string, port: number): string {
-	const seg = host.indexOf(':') < 0 ? host : `[${host}]`
-	return `${seg}:${port}`
-}
 
 /**
  * Representation of a single job to be executed.
@@ -72,55 +55,4 @@ export interface Client extends TypedEmitter<ClientEvents> {
 	 * @param port - port number of daemon on the host
 	 */
 	introduce(host: string, port: number): void
-}
-
-/**
- * A mock Junknet client using HTTP/2.
- * It distributes the given jobs among daemons it knows about.
- * @deprecated Implement a {@link Client} using SSH instead.
- */
-export class Http2Client extends EventEmitter implements Client {
-	/**
-	 * Create a client whose responsibility is to finish the given jobs.
-	 * It won't start until it knows about some daemons.
-	 *
-	 * @param queue - array of jobs in reverse order
-	 */
-	constructor(private readonly queue: Job[]) {
-		super()
-	}
-
-	/**
-	 * Add a new daemon to the swarm.
-	 * The client may now give jobs to this daemon.
-	 *
-	 * @param host - hostname or IP address of daemon
-	 * @param port - port number of daemon on the host
-	 * @override
-	 */
-	introduce(host: string, port: number): void {
-		const client = connect(`http://${hostAndPort(host, port)}`)
-		client.on('error', (err) => this.emit('error', err))
-		this.available(client)
-	}
-
-	private available(client: ClientHttp2Session): void {
-		const job = this.queue.pop()
-		if (!job) {
-			client.close(() => this.emit('done'))
-			return
-		}
-
-		const req = client.request({ ':path': `/${job}` })
-		client.on('error', (err) => this.emit('error', err))
-
-		let data = ''
-		req.setEncoding('utf8')
-		req.on('data', (chunk) => (data += chunk))
-
-		req.on('end', () => {
-			this.emit('progress', job, data)
-			this.available(client)
-		})
-	}
 }

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -25,6 +25,13 @@ function hostAndPort(host: string, port: number): string {
 export type Job = string
 
 /**
+ * Representation of the output of a single job.
+ * Obviously, in the future this will not just be a string.
+ * @experimental
+ */
+export type JobResult = string
+
+/**
  * Model for events emitted by {@link Client}.
  * @experimental
  */
@@ -40,9 +47,9 @@ export interface ClientEvents {
 	 * One job completed, and returned some data.
 	 *
 	 * @param job - the job which completed
-	 * @param data - the result of the job
+	 * @param data - the result of that job
 	 */
-	progress(job: Job, data: string): void
+	progress(job: Job, data: JobResult): void
 
 	/**
 	 * All jobs have completed.

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -34,7 +34,7 @@ export type Job = string
  *
  * @experimental
  */
-export default class Client extends EventEmitter {
+export class Client extends EventEmitter {
 	/**
 	 * Create a client whose responsibility is to finish the given jobs.
 	 * It won't start until it knows about some daemons.

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -52,10 +52,27 @@ export interface ClientEvents {
 }
 
 /**
- * A Junknet client. It distributes the given jobs among daemons it knows about.
+ * A Junknet client.
+ * It's responsible for finishing some jobs by distributing them among daemons it knows about.
  * @experimental
  */
-export class Client extends (EventEmitter as new () => TypedEmitter<ClientEvents>) {
+export interface Client extends TypedEmitter<ClientEvents> {
+	/**
+	 * Add a new daemon to the swarm.
+	 * The client may now give jobs to this daemon.
+	 *
+	 * @param host - hostname or IP address of daemon
+	 * @param port - port number of daemon on the host
+	 */
+	introduce(host: string, port: number): void
+}
+
+/**
+ * A mock Junknet client using HTTP/2.
+ * It distributes the given jobs among daemons it knows about.
+ * @deprecated Implement a {@link Client} using SSH instead.
+ */
+export class Http2Client extends EventEmitter implements Client {
 	/**
 	 * Create a client whose responsibility is to finish the given jobs.
 	 * It won't start until it knows about some daemons.
@@ -72,6 +89,7 @@ export class Client extends (EventEmitter as new () => TypedEmitter<ClientEvents
 	 *
 	 * @param host - hostname or IP address of daemon
 	 * @param port - port number of daemon on the host
+	 * @override
 	 */
 	introduce(host: string, port: number): void {
 		const client = connect(`http://${hostAndPort(host, port)}`)

--- a/src/Http2Client.ts
+++ b/src/Http2Client.ts
@@ -48,6 +48,11 @@ export class Http2Client extends EventEmitter implements Client {
 		this.available(client)
 	}
 
+	/**
+	 * Drive the given daemon, by providing it with one task at a time in an async loop.
+	 *
+	 * @param client - a HTTP/2 client connected to a daemon.
+	 */
 	private available(client: ClientHttp2Session): void {
 		const job = this.queue.pop()
 		if (!job) {

--- a/src/Http2Client.ts
+++ b/src/Http2Client.ts
@@ -1,0 +1,70 @@
+import { ClientHttp2Session, connect } from 'http2'
+import { EventEmitter } from 'events'
+
+import { Client, Job } from './Client'
+
+/**
+ * String representation of the host and port together.
+ *
+ * @remarks
+ * Needed because IPv6 addresses must be bracketed to disambiguate colons.
+ *
+ * @param host - hostname or IP address
+ * @param port - port number
+ * @returns connection string suitable for a URL
+ */
+function hostAndPort(host: string, port: number): string {
+	const seg = host.indexOf(':') < 0 ? host : `[${host}]`
+	return `${seg}:${port}`
+}
+
+/**
+ * A mock Junknet client using HTTP/2.
+ * It distributes the given jobs among daemons it knows about.
+ * @deprecated Implement a {@link Client} using SSH instead.
+ */
+export class Http2Client extends EventEmitter implements Client {
+	/**
+	 * Create a client whose responsibility is to finish the given jobs.
+	 * It won't start until it knows about some daemons.
+	 *
+	 * @param queue - array of jobs in reverse order
+	 */
+	constructor(private readonly queue: Job[]) {
+		super()
+	}
+
+	/**
+	 * Add a new daemon to the swarm.
+	 * The client may now give jobs to this daemon.
+	 *
+	 * @param host - hostname or IP address of daemon
+	 * @param port - port number of daemon on the host
+	 * @override
+	 */
+	introduce(host: string, port: number): void {
+		const client = connect(`http://${hostAndPort(host, port)}`)
+		client.on('error', (err) => this.emit('error', err))
+		this.available(client)
+	}
+
+	private available(client: ClientHttp2Session): void {
+		const job = this.queue.pop()
+		if (!job) {
+			client.close(() => this.emit('done'))
+			return
+		}
+
+		const req = client.request({ ':path': `/${job}` })
+		client.on('error', (err) => this.emit('error', err))
+
+		let data = ''
+		req.setEncoding('utf8')
+		req.on('data', (chunk) => (data += chunk))
+
+		req.on('end', () => {
+			this.emit('progress', job, data)
+			this.available(client)
+		})
+	}
+}

--- a/src/ZeroconfClient.ts
+++ b/src/ZeroconfClient.ts
@@ -1,4 +1,4 @@
-import Client from './Client'
+import { Client } from './Client'
 import { SERVICE_TYPE } from './Constants'
 
 import { Bonjour, Browser } from 'bonjour'

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { supplyClient } from './ZeroconfClient'
-import { Client, Http2Client } from './Client'
+import { Client } from './Client'
+import { Http2Client } from './Http2Client'
 
 import * as bonjour from 'bonjour'
 import { once } from 'events'

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { supplyClient } from './ZeroconfClient'
-import Client from './Client'
+import { Client } from './Client'
 
 import * as bonjour from 'bonjour'
 import { once } from 'events'

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { supplyClient } from './ZeroconfClient'
-import { Client } from './Client'
+import { Client, Http2Client } from './Client'
 
 import * as bonjour from 'bonjour'
 import { once } from 'events'
@@ -15,7 +15,13 @@ function done() {
 	zeroconf.destroy()
 }
 
-const client = new Client(['fifth', 'fourth', 'third', 'second', 'first'])
+const client: Client = new Http2Client([
+	'fifth',
+	'fourth',
+	'third',
+	'second',
+	'first',
+])
 client.on('progress', console.log)
 once(client, 'done').then(done).catch(console.error)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Constants'
 export * from './Daemon'
 export * from './Client'
+export * from './Http2Client'
 export * from './ZeroconfDaemon'
 export * from './ZeroconfClient'


### PR DESCRIPTION
This makes it easier to write unit tests, and is better software design practice anyway (interface segregation principle? dependency inversion? one of those things 😄). It will be needed by the testing PR for Zeroconf (yet to come); pushing this separately so it can be incorporated into TopoSort code.

It also makes the events emitted by Client be strictly typed. Among other things, this makes it so your IDE shows you what events are possible as you write code that consumes this interface.