### PR TITLE
Remove `-f Makefile` functionality from CommandLineController.

### DIFF
--- a/src/Controller/CommandLineController.ts
+++ b/src/Controller/CommandLineController.ts
@@ -6,8 +6,13 @@ import yargs from 'yargs'
  */
 export interface ArgvData {
 	/**
-	 * The makefile specified by the user (eg. `build.make`).
-	 * Set to `undefined` if no file was specified.
+	 * Unused; right now, it's hardcoded to 'Makefile'.
+	 *
+	 * Its intent was to capture the makefile specified by the user (eg.
+	 * `build.make`), and to be `undefined` when no Makefile was specified.
+	 *
+	 * We cut this functionality due to time constraints; it's preserved here
+	 * for compatibility + futureproofing.
 	 */
 	makefile: string | undefined
 
@@ -57,19 +62,12 @@ export function interpretArgv(argv: readonly string[]): ArgvData {
 		.usage(
 			'Build a makefile target in parallel, given a docker image and' +
 				'a list of targets\nUsage: ' +
-				'junknet [-f makefile] docker-image [target1 target2...]',
+				'junknet docker-image [target1 target2...]',
 		)
 		.epilogue(
 			'for more information, read our manual ' +
 				'at https://github.com/cs130-w21/1',
 		)
-		.options({
-			f: {
-				alias: 'makefile',
-				type: 'string',
-				desc: 'The Makefile to process',
-			},
-		})
 		.exitProcess(false) // Don't `process.exit()` on invalid options.
 		.version() // SIDE EFFECT: parses package.json for version info.
 		.help().argv
@@ -77,7 +75,7 @@ export function interpretArgv(argv: readonly string[]): ArgvData {
 	// Exit when given `--help` or `--version`.
 	if (yargsArgv.help !== undefined || yargsArgv.version !== undefined) {
 		return {
-			makefile: undefined,
+			makefile: 'Makefile',
 			dockerImage: '',
 			targets: [],
 			cleanExit: true,
@@ -101,7 +99,7 @@ export function interpretArgv(argv: readonly string[]): ArgvData {
 	// invalidArguments flag.
 	if (dockerImage === undefined) {
 		return {
-			makefile: undefined,
+			makefile: 'Makefile',
 			dockerImage: '',
 			targets: [],
 			cleanExit: false,
@@ -110,7 +108,7 @@ export function interpretArgv(argv: readonly string[]): ArgvData {
 	}
 
 	return {
-		makefile: yargsArgv.f,
+		makefile: 'Makefile',
 		dockerImage,
 		targets,
 		cleanExit: false,

--- a/test/unit/CommandLineController.test.ts
+++ b/test/unit/CommandLineController.test.ts
@@ -5,40 +5,6 @@ import * as cli from '../../src/Controller/CommandLineController'
  */
 
 describe('CommandLineController', () => {
-	it('interprets short options', () => {
-		const argv: readonly string[] = ['-f', 'myMakefile.make', 'ubuntu:18.04']
-		const results = cli.interpretArgv(argv)
-		expect(results.makefile).toBe('myMakefile.make')
-		expect(results.dockerImage).toBe('ubuntu:18.04')
-		expect(results.invalidArguments).toBe(false)
-		expect(results.cleanExit).toBe(false)
-	})
-
-	it('interprets --option=var style long options', () => {
-		const argv: readonly string[] = [
-			'--makefile=myMakefile.make',
-			'ubuntu:18.04',
-		]
-		const results = cli.interpretArgv(argv)
-		expect(results.makefile).toBe('myMakefile.make')
-		expect(results.dockerImage).toBe('ubuntu:18.04')
-		expect(results.invalidArguments).toBe(false)
-		expect(results.cleanExit).toBe(false)
-	})
-
-	it('interprets "--option var" style long options', () => {
-		const argv: readonly string[] = [
-			'--makefile',
-			'myMakefile.make',
-			'ubuntu:18.04',
-		]
-		const results = cli.interpretArgv(argv)
-		expect(results.makefile).toBe('myMakefile.make')
-		expect(results.dockerImage).toBe('ubuntu:18.04')
-		expect(results.invalidArguments).toBe(false)
-		expect(results.cleanExit).toBe(false)
-	})
-
 	it('interprets first positional argument as container name', () => {
 		const argv: readonly string[] = ['ubuntu:latest']
 		const results = cli.interpretArgv(argv)
@@ -52,6 +18,7 @@ describe('CommandLineController', () => {
 		const results = cli.interpretArgv(argv)
 		expect(results.dockerImage).toBe('ubuntu:latest')
 		expect(results.targets.sort()).toStrictEqual(['all', 'clean'].sort())
+		expect(results.makefile).toBe('Makefile')
 		expect(results.invalidArguments).toBe(false)
 		expect(results.cleanExit).toBe(false)
 	})
@@ -62,7 +29,6 @@ describe('CommandLineController', () => {
 		expect(results.cleanExit).toBe(false)
 		expect(results.dockerImage).toBe('ubuntu:18.04')
 		expect(results.targets).toEqual([])
-		expect(results.makefile).toBeUndefined()
 		expect(results.invalidArguments).toBe(false)
 		expect(results.cleanExit).toBe(false)
 	})
@@ -95,5 +61,13 @@ describe('CommandLineController', () => {
 
 		// Restore regular console functionality.
 		spy.mockRestore()
+	})
+
+	it('always returns "Makefile" as the specified makefile', () => {
+		const argv: readonly string[] = ['ubuntu:18.04']
+		const results = cli.interpretArgv(argv)
+		expect(results.makefile).toBe('Makefile')
+		expect(results.invalidArguments).toBe(false)
+		expect(results.cleanExit).toBe(false)
 	})
 })


### PR DESCRIPTION
We're cutting this due to time.